### PR TITLE
Add OpenAPI documentation

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,9 @@ var calculateDigest = require('./digest.js');
 
 var MIME_TYPES = {
     '.html': 'text/html',
-    '.ico': 'image/x-icon'
+    '.ico': 'image/x-icon',
+    '.yaml': 'application/yaml',
+    '.yml': 'application/yaml'
 };
 
 var publicDir = path.join(__dirname, 'public');
@@ -58,6 +60,32 @@ function createApp() {
         if (url.pathname === '/algorithms' && req.method === 'GET') {
             res.writeHead(200, { 'content-type': 'application/json' });
             res.end(JSON.stringify(crypto.getHashes()));
+            return;
+        }
+
+        if (url.pathname === '/docs' && req.method === 'GET') {
+            res.writeHead(200, { 'content-type': 'text/html' });
+            res.end(`<!doctype html>
+<html>
+  <head>
+    <title>Ecosyste.ms Digest API docs</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <script>
+      window.onload = () => {
+        window.ui = SwaggerUIBundle({
+          url: '/openapi.yaml',
+          dom_id: '#swagger-ui'
+        });
+      };
+    </script>
+  </body>
+</html>`);
             return;
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
         </h1>
         <div class="col-lg-6 mx-auto">
           <p class="lead mb-4">
-            An open API service providing digests of packages from many open source software ecosystems and registries. 
+            An open API service providing digests of packages from many open source software ecosystems and registries.
           </p>
         </div>
       </div>
@@ -37,16 +37,17 @@
     </div>
 
     <footer class="py-5 container-sm text-muted text-center">
-      <a class="link-dark" target="_blank" href="https://ecosyste.ms">About</a> — 
-      <a class="link-dark" target="_blank" href="https://blog.ecosyste.ms">Blog</a> — 
+      <a class="link-dark" href="/docs">API Docs</a> —
+      <a class="link-dark" target="_blank" href="https://ecosyste.ms">About</a> —
+      <a class="link-dark" target="_blank" href="https://blog.ecosyste.ms">Blog</a> —
       <a class="link-dark" target="_blank" href="https://ecosystems.appsignal-status.com/">Status</a>
       <br/>
-      <a class="link-dark" target="_blank" href="https://github.com/ecosyste-ms/digest">GitHub</a> — 
-      <a class="link-dark" target="_blank" href="https://opencollective.com/ecosystems">Open Collective</a> — 
-      <a class="link-dark" target="_blank" href="https://twitter.com/ecosyste_ms">Twitter</a> — 
+      <a class="link-dark" target="_blank" href="https://github.com/ecosyste-ms/digest">GitHub</a> —
+      <a class="link-dark" target="_blank" href="https://opencollective.com/ecosystems">Open Collective</a> —
+      <a class="link-dark" target="_blank" href="https://twitter.com/ecosyste_ms">Twitter</a> —
       <a class="link-dark" target="_blank" href="https://mastodon.social/@ecosystems">Mastodon</a>
       <br/>
-      Code: <a class="link-dark" href="https://github.com/ecosyste-ms/digest/blob/main/LICENSE">AGPL-3</a>  — 
+      Code: <a class="link-dark" href="https://github.com/ecosyste-ms/digest/blob/main/LICENSE">AGPL-3</a>  —
       Data: <a class="link-dark" target="_blank" href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>
     </footer>
   </body>

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.3
+info:
+  title: Ecosyste.ms Digest API
+  version: 1.0.0
+  description: |
+    API for calculating package/file digests and listing supported hashing
+    algorithms.
+servers:
+  - url: /
+paths:
+  /algorithms:
+    get:
+      summary: List supported hashing algorithms
+      responses:
+        '200':
+          description: Array of algorithm names supported by Node.js crypto
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              example:
+                - sha256
+                - sha512
+                - md5
+  /digest:
+    get:
+      summary: Calculate a digest for a remote URL
+      parameters:
+        - name: url
+          in: query
+          required: true
+          description: URL of the file to fetch and digest
+          schema:
+            type: string
+            format: uri
+          example: https://registry.npmjs.org/playwright/-/playwright-1.0.2.tgz
+        - name: algorithm
+          in: query
+          required: false
+          description: Hash algorithm. Defaults to sha256.
+          schema:
+            type: string
+            default: sha256
+          example: sha256
+        - name: encoding
+          in: query
+          required: false
+          description: Digest encoding. Defaults to hex.
+          schema:
+            type: string
+            default: hex
+          example: hex
+      responses:
+        '200':
+          description: Digest result or error payload
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/DigestResponse'
+                  - $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    DigestResponse:
+      type: object
+      required:
+        - algorithm
+        - encoding
+        - digest
+        - url
+        - bytes
+        - sri
+      properties:
+        algorithm:
+          type: string
+          example: sha256
+        encoding:
+          type: string
+          example: hex
+        digest:
+          type: string
+          example: c0ffee
+        url:
+          type: string
+          format: uri
+        bytes:
+          type: string
+          description: Number of bytes fetched as a string.
+          example: '12345'
+        sri:
+          type: string
+          example: sha256-c0ffee
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          description: Error returned while fetching or digesting the URL.

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -185,6 +185,34 @@ describe('static files', () => {
   });
 });
 
+
+describe('API documentation', () => {
+  var server;
+
+  before(() => {
+    var app = createApp();
+    server = app.listen(0);
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  it('serves openapi.yaml', async () => {
+    var res = await request(server, '/openapi.yaml');
+    assert.strictEqual(res.status, 200);
+    assert.ok(res.headers['content-type'].includes('application/yaml'));
+    assert.ok(res.body.includes('openapi: 3.0.3'));
+  });
+
+  it('serves swagger docs at /docs', async () => {
+    var res = await request(server, '/docs');
+    assert.strictEqual(res.status, 200);
+    assert.ok(res.headers['content-type'].includes('text/html'));
+    assert.ok(res.body.includes('/openapi.yaml'));
+  });
+});
+
 describe('404 handling', () => {
   var server;
 


### PR DESCRIPTION
## Summary

Adds API documentation for the Digest service:

- adds `public/openapi.yaml` describing `/algorithms` and `/digest`
- serves a Swagger UI page at `/docs`
- serves the OpenAPI spec from `/openapi.yaml`
- links the docs page from the public footer
- adds regression tests for both documentation routes

## Testing

- `npm test`

All tests pass: 26 passing, 0 failing.

Fixes #8