### PR TITLE
Add Go module dirhash support

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -1,9 +1,100 @@
 var crypto = require('crypto');
+var zlib = require('zlib');
+
+function readUInt16(buffer, offset) {
+    return buffer.readUInt16LE(offset);
+}
+
+function readUInt32(buffer, offset) {
+    return buffer.readUInt32LE(offset);
+}
+
+function findEndOfCentralDirectory(buffer) {
+    var minOffset = Math.max(0, buffer.length - 0xffff - 22);
+    for (var offset = buffer.length - 22; offset >= minOffset; offset--) {
+        if (readUInt32(buffer, offset) === 0x06054b50) {
+            return offset;
+        }
+    }
+    throw new Error('Invalid zip file: central directory not found');
+}
+
+function normalizeZipPath(path) {
+    var parts = path.split('/').filter(Boolean);
+    if (parts.length > 1) {
+        parts.shift();
+    }
+    return parts.join('/');
+}
+
+function extractZipFile(buffer, entry) {
+    if (readUInt32(buffer, entry.localHeaderOffset) !== 0x04034b50) {
+        throw new Error('Invalid zip file: local header not found');
+    }
+    var nameLength = readUInt16(buffer, entry.localHeaderOffset + 26);
+    var extraLength = readUInt16(buffer, entry.localHeaderOffset + 28);
+    var dataOffset = entry.localHeaderOffset + 30 + nameLength + extraLength;
+    var compressed = buffer.subarray(dataOffset, dataOffset + entry.compressedSize);
+
+    if (entry.compressionMethod === 0) {
+        return compressed;
+    }
+    if (entry.compressionMethod === 8) {
+        return zlib.inflateRawSync(compressed);
+    }
+    throw new Error(`Unsupported zip compression method: ${entry.compressionMethod}`);
+}
+
+function zipDirhash(buffer) {
+    var eocdOffset = findEndOfCentralDirectory(buffer);
+    var entryCount = readUInt16(buffer, eocdOffset + 10);
+    var centralDirectoryOffset = readUInt32(buffer, eocdOffset + 16);
+    var entries = [];
+    var offset = centralDirectoryOffset;
+
+    for (var i = 0; i < entryCount; i++) {
+        if (readUInt32(buffer, offset) !== 0x02014b50) {
+            throw new Error('Invalid zip file: central directory entry not found');
+        }
+        var compressionMethod = readUInt16(buffer, offset + 10);
+        var compressedSize = readUInt32(buffer, offset + 20);
+        var uncompressedSize = readUInt32(buffer, offset + 24);
+        var fileNameLength = readUInt16(buffer, offset + 28);
+        var extraLength = readUInt16(buffer, offset + 30);
+        var commentLength = readUInt16(buffer, offset + 32);
+        var localHeaderOffset = readUInt32(buffer, offset + 42);
+        var fileName = buffer.subarray(offset + 46, offset + 46 + fileNameLength).toString('utf8');
+        var normalizedPath = normalizeZipPath(fileName);
+
+        if (normalizedPath !== '' && !fileName.endsWith('/')) {
+            entries.push({
+                path: normalizedPath,
+                compressionMethod,
+                compressedSize,
+                uncompressedSize,
+                localHeaderOffset,
+            });
+        }
+
+        offset += 46 + fileNameLength + extraLength + commentLength;
+    }
+
+    entries.sort((a, b) => a.path.localeCompare(b.path));
+    var lines = entries.map((entry) => {
+        var contents = extractZipFile(buffer, entry);
+        if (contents.length !== entry.uncompressedSize) {
+            throw new Error(`Invalid zip file: size mismatch for ${entry.path}`);
+        }
+        var fileHash = crypto.createHash('sha256').update(contents).digest('hex');
+        return `${fileHash}  ${entry.path}\n`;
+    }).join('');
+
+    return 'h1:' + crypto.createHash('sha256').update(lines).digest('base64');
+}
 
 async function calculateDigest(algorithm, encoding, url) {
     algorithm = (typeof algorithm !== 'undefined') ?  algorithm : 'sha256'
     encoding = (typeof encoding !== 'undefined') ?  encoding : 'hex'
-    // TODO support go modules hashing algo
 
     var controller = new AbortController();
     var timeout = setTimeout(() => controller.abort(), 1000*5);
@@ -17,13 +108,18 @@ async function calculateDigest(algorithm, encoding, url) {
     // TODO only digest if response is a success (example: 403 with body - https://rubygems.org/downloads/sorbet-static-0.4.5125.gem)
 
     var bytes = response.headers.get('content-length');
-    var body = await response.text();
+    var body = Buffer.from(await response.arrayBuffer());
 
     if (!bytes) {
-      bytes = String(Buffer.byteLength(body));
+      bytes = String(body.length);
     }
 
-    var digest = crypto.createHash(algorithm).update(body).digest(encoding);
+    var digest;
+    if (algorithm === 'dirhash') {
+      digest = zipDirhash(body);
+    } else {
+      digest = crypto.createHash(algorithm).update(body).digest(encoding);
+    }
     var sri = `${algorithm}-${digest}`
     return {algorithm, encoding, digest, url, bytes, sri}
 }

--- a/test/digest.test.js
+++ b/test/digest.test.js
@@ -2,11 +2,79 @@ var { describe, it, before, after } = require('node:test');
 var assert = require('node:assert');
 var http = require('node:http');
 var crypto = require('node:crypto');
+var zlib = require('node:zlib');
 var calculateDigest = require('../digest.js');
 
 var testContent = 'hello world';
 var testServer;
 var testUrl;
+
+function crc32(buffer) {
+    var table = crc32.table || (crc32.table = Array.from({ length: 256 }, (_, i) => {
+        var c = i;
+        for (var k = 0; k < 8; k++) {
+            c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        }
+        return c >>> 0;
+    }));
+    var crc = 0xffffffff;
+    for (var byte of buffer) {
+        crc = table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+function makeZip(files) {
+    var localParts = [];
+    var centralParts = [];
+    var offset = 0;
+    for (var [name, content] of files) {
+        var nameBuffer = Buffer.from(name);
+        var contentBuffer = Buffer.from(content);
+        var compressed = zlib.deflateRawSync(contentBuffer);
+        var crc = crc32(contentBuffer);
+        var local = Buffer.alloc(30 + nameBuffer.length);
+        local.writeUInt32LE(0x04034b50, 0);
+        local.writeUInt16LE(20, 4);
+        local.writeUInt16LE(8, 8);
+        local.writeUInt32LE(crc, 14);
+        local.writeUInt32LE(compressed.length, 18);
+        local.writeUInt32LE(contentBuffer.length, 22);
+        local.writeUInt16LE(nameBuffer.length, 26);
+        nameBuffer.copy(local, 30);
+        localParts.push(local, compressed);
+
+        var central = Buffer.alloc(46 + nameBuffer.length);
+        central.writeUInt32LE(0x02014b50, 0);
+        central.writeUInt16LE(20, 4);
+        central.writeUInt16LE(20, 6);
+        central.writeUInt16LE(8, 10);
+        central.writeUInt32LE(crc, 16);
+        central.writeUInt32LE(compressed.length, 20);
+        central.writeUInt32LE(contentBuffer.length, 24);
+        central.writeUInt16LE(nameBuffer.length, 28);
+        central.writeUInt32LE(offset, 42);
+        nameBuffer.copy(central, 46);
+        centralParts.push(central);
+        offset += local.length + compressed.length;
+    }
+    var centralDirectory = Buffer.concat(centralParts);
+    var eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(files.length, 8);
+    eocd.writeUInt16LE(files.length, 10);
+    eocd.writeUInt32LE(centralDirectory.length, 12);
+    eocd.writeUInt32LE(offset, 16);
+    return Buffer.concat([...localParts, centralDirectory, eocd]);
+}
+
+function expectedDirhash(files) {
+    var lines = files
+        .map(([path, content]) => `${crypto.createHash('sha256').update(content).digest('hex')}  ${path.split('/').slice(1).join('/')}\n`)
+        .sort()
+        .join('');
+    return 'h1:' + crypto.createHash('sha256').update(lines).digest('base64');
+}
 
 before(() => {
     return new Promise((resolve) => {
@@ -20,6 +88,10 @@ before(() => {
             } else if (req.url === '/large-header') {
                 res.writeHead(200, { 'content-length': '999' });
                 res.end(testContent);
+            } else if (req.url === '/module.zip') {
+                var zip = makeZip([['example.com/mod@v1.0.0/go.mod', 'module example.com/mod\n'], ['example.com/mod@v1.0.0/main.go', 'package main\n']]);
+                res.writeHead(200, { 'content-length': String(zip.length) });
+                res.end(zip);
             } else if (req.url === '/binary') {
                 var buf = Buffer.from([0x00, 0x01, 0x02, 0xff]);
                 res.writeHead(200, { 'content-length': String(buf.length) });
@@ -94,9 +166,18 @@ describe('calculateDigest', () => {
         assert.strictEqual(result.digest, expected);
     });
 
-    it('hashes binary content as string', async () => {
+    it('hashes binary content as bytes', async () => {
         var result = await calculateDigest(undefined, undefined, testUrl + '/binary');
-        assert.ok(result.digest);
+        var expected = crypto.createHash('sha256').update(Buffer.from([0x00, 0x01, 0x02, 0xff])).digest('hex');
+        assert.strictEqual(result.digest, expected);
         assert.strictEqual(result.algorithm, 'sha256');
+    });
+
+    it('supports Go module dirhash for zip archives', async () => {
+        var files = [['example.com/mod@v1.0.0/go.mod', 'module example.com/mod\n'], ['example.com/mod@v1.0.0/main.go', 'package main\n']];
+        var result = await calculateDigest('dirhash', undefined, testUrl + '/module.zip');
+        assert.strictEqual(result.algorithm, 'dirhash');
+        assert.strictEqual(result.digest, expectedDirhash(files));
+        assert.strictEqual(result.sri, `dirhash-${result.digest}`);
     });
 });


### PR DESCRIPTION
## Summary
- adds `dirhash` as a supported digest algorithm for Go module zip archives
- computes the Go-style `h1:` directory hash from sorted file content hashes
- parses stored and deflated zip entries without adding new dependencies
- switches digest input handling to bytes so binary artifacts hash correctly

## Validation
- `npm test`
- `git diff --check`

Fixes #1