### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for automated Node.js test runs
- run the existing `npm test` suite on pushes, pull requests, and manual dispatch
- cover Node.js 18, 20, and 22 with npm dependency caching

## Validation
- `npm test` (26 tests passing)
- parsed `.github/workflows/test.yml` with PyYAML
- `git diff --check`

Fixes #11