### PR TITLE
Add dirhash support for Go module zips

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -1,10 +1,11 @@
 var crypto = require('crypto');
+var fs = require('fs-extra');
+var tmp = require('tmp-promise');
+var { zipDigest } = require('zipdigest');
 
 async function calculateDigest(algorithm, encoding, url) {
     algorithm = (typeof algorithm !== 'undefined') ?  algorithm : 'sha256'
     encoding = (typeof encoding !== 'undefined') ?  encoding : 'hex'
-    // TODO support go modules hashing algo
-
     var controller = new AbortController();
     var timeout = setTimeout(() => controller.abort(), 1000*5);
 
@@ -16,16 +17,42 @@ async function calculateDigest(algorithm, encoding, url) {
 
     // TODO only digest if response is a success (example: 403 with body - https://rubygems.org/downloads/sorbet-static-0.4.5125.gem)
 
+    if (algorithm === 'dirhash') {
+      return await calculateDirhash(url, response);
+    }
+
     var bytes = response.headers.get('content-length');
-    var body = await response.text();
+    var body = Buffer.from(await response.arrayBuffer());
 
     if (!bytes) {
-      bytes = String(Buffer.byteLength(body));
+      bytes = String(body.byteLength);
     }
 
     var digest = crypto.createHash(algorithm).update(body).digest(encoding);
     var sri = `${algorithm}-${digest}`
     return {algorithm, encoding, digest, url, bytes, sri}
+}
+
+async function calculateDirhash(url, response) {
+    var dir = await tmp.dir({ unsafeCleanup: true });
+    var zippath = `${dir.path}/module.zip`;
+
+    try {
+      var body = Buffer.from(await response.arrayBuffer());
+      await fs.writeFile(zippath, body);
+      var digest = `h1:${await zipDigest(zippath)}`;
+
+      return {
+        algorithm: 'dirhash',
+        encoding: 'base64',
+        digest,
+        url,
+        bytes: String(body.byteLength),
+        sri: `dirhash-${digest}`
+      };
+    } finally {
+      await dir.cleanup();
+    }
 }
 
 module.exports = calculateDigest;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,94 @@
       "name": "digest",
       "version": "1.0.0",
       "license": "AGPL-3.0-only",
+      "dependencies": {
+        "fs-extra": "^11.3.4",
+        "tmp-promise": "^3.0.3",
+        "zipdigest": "^1.0.0"
+      },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/node-stream-zip": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
+      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/antelle"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/zipdigest": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/zipdigest/-/zipdigest-1.0.0.tgz",
+      "integrity": "sha512-hbp0SyUpma9lNzr2URMvIsOvdcnEv5m4oML1LQT3Z7nCJ8td8RNRUisBx9Bn20vxY3GydY5N4EL9jVmF2KrIZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-stream-zip": "^1.13.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "node": ">=18"
   },
   "dependencies": {
+    "fs-extra": "^11.3.4",
+    "tmp-promise": "^3.0.3",
+    "zipdigest": "^1.0.0"
   }
 }

--- a/test/digest.test.js
+++ b/test/digest.test.js
@@ -94,9 +94,20 @@ describe('calculateDigest', () => {
         assert.strictEqual(result.digest, expected);
     });
 
-    it('hashes binary content as string', async () => {
+    it('hashes binary content as bytes', async () => {
         var result = await calculateDigest(undefined, undefined, testUrl + '/binary');
-        assert.ok(result.digest);
+        var expected = crypto.createHash('sha256').update(Buffer.from([0x00, 0x01, 0x02, 0xff])).digest('hex');
+        assert.strictEqual(result.digest, expected);
         assert.strictEqual(result.algorithm, 'sha256');
+    });
+
+    it('supports dirhash for go module zip files', async () => {
+        var result = await calculateDigest('dirhash', undefined, 'https://github.com/foragepm/zipdigest/archive/refs/tags/v1.0.0.zip');
+
+        assert.strictEqual(result.algorithm, 'dirhash');
+        assert.strictEqual(result.encoding, 'base64');
+        assert.ok(result.digest.startsWith('h1:'));
+        assert.strictEqual(result.sri, `dirhash-${result.digest}`);
+        assert.ok(Number(result.bytes) > 0);
     });
 });


### PR DESCRIPTION
## Summary
- add `dirhash` as an algorithm option for Go module zip hashes
- use `zipdigest` to compute the module zip digest and return it in `h1:` format
- hash fetched content as bytes instead of text for normal digests
- add regression coverage for binary hashing and dirhash

Refs #1

## Validation
- `npm test`
- `git diff --check`