### PR TITLE
Hash raw response bytes, not UTF-8-decoded text

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -17,13 +17,13 @@ async function calculateDigest(algorithm, encoding, url) {
     // TODO only digest if response is a success (example: 403 with body - https://rubygems.org/downloads/sorbet-static-0.4.5125.gem)
 
     var bytes = response.headers.get('content-length');
-    var body = await response.text();
+    var buf = Buffer.from(await response.arrayBuffer());
 
     if (!bytes) {
-      bytes = String(Buffer.byteLength(body));
+      bytes = String(buf.length);
     }
 
-    var digest = crypto.createHash(algorithm).update(body).digest(encoding);
+    var digest = crypto.createHash(algorithm).update(buf).digest(encoding);
     var sri = `${algorithm}-${digest}`
     return {algorithm, encoding, digest, url, bytes, sri}
 }

--- a/test/digest.test.js
+++ b/test/digest.test.js
@@ -94,9 +94,11 @@ describe('calculateDigest', () => {
         assert.strictEqual(result.digest, expected);
     });
 
-    it('hashes binary content as string', async () => {
+    it('hashes binary content by raw bytes, not utf-8 decoded text', async () => {
         var result = await calculateDigest(undefined, undefined, testUrl + '/binary');
-        assert.ok(result.digest);
-        assert.strictEqual(result.algorithm, 'sha256');
+        var raw = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+        var expected = crypto.createHash('sha256').update(raw).digest('hex');
+        assert.strictEqual(result.digest, expected);
+        assert.strictEqual(result.bytes, String(raw.length));
     });
 });


### PR DESCRIPTION
`digest.js` reads the response with `response.text()` and hashes the resulting string. `text()` decodes the body as UTF-8; for binary artifacts (crates, jars, gems, tarballs — nearly every package) the decode→re-encode round-trip is lossy (invalid bytes become U+FFFD), so the bytes hashed aren't the bytes downloaded, and the digest matches no real `sha256sum`.

**Repro (current main):**
```
$ curl -sL https://static.crates.io/crates/anyhow/anyhow-1.0.86.crate | sha256sum
b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da
$ curl -s 'https://digest.ecosyste.ms/digest?algorithm=sha256&encoding=hex&url=https://static.crates.io/crates/anyhow/anyhow-1.0.86.crate'
..."digest":"54cea7440d67ac264393b8326f6a5eda20ae3ac599ec4b9b0b8429589fc4e7cf"...
```
Plain-text URLs hash correctly, isolating the cause to binary content.

**Fix:** read `response.arrayBuffer()` and hash the raw bytes. After the fix the same crate returns `b3d1d046...`, and a Maven `.jar` returns `6591a197...`, both matching independent `sha256sum`.

**Test:** the existing `/binary` test only asserted the digest was truthy; tightened it to assert the exact raw-bytes digest. It fails on the old code, passes on the fix.

Relevant to ecosyste-ms/packages#1630 / #1631 — a digest backfill on the current code would populate hashes that never match real artifacts.